### PR TITLE
Hex wrapper for json fields

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ set(sources
 	include/nemcpp/config.h
 	include/nemcpp/exceptions.h
 	include/nemcpp/sdk.h
+	include/nemcpp/traits.h
 	include/nemcpp/types.h
 	include/nemcpp/crypto/hash.h
 	include/nemcpp/crypto/key_pair.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,7 @@ set(sources
 	src/infrastructure/binary/parser.h
 	src/infrastructure/binary/dto/transaction_dto.h
 	src/infrastructure/json/descriptors.h
+	src/infrastructure/json/hex.h
 	src/infrastructure/json/parser.cpp
 	src/infrastructure/json/parser.h
 	src/infrastructure/json/uint64.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,7 @@ set(sources
 	include/nemcpp/utils/bitwise_enum.h
 	include/nemcpp/utils/buffer.h
 	include/nemcpp/utils/comparator.h
+	include/nemcpp/utils/format.h
 	include/nemcpp/utils/hashable_array.h
 	include/nemcpp/utils/hasher.h
 	include/nemcpp/utils/lazy.h

--- a/include/nemcpp/model/account/address.h
+++ b/include/nemcpp/model/account/address.h
@@ -46,11 +46,17 @@ namespace nem2_sdk {
 		const AddressData& binary() const;
 		
 		/// Returns base32-encoded address.
-		const std::string& encoded() const;
-		
+		const std::string& encoded() const&;
+
+		/// Returns base32-encoded address.
+		std::string&& encoded() &&;
+
 		/// Returns pretty-print address.
-		const std::string& pretty() const;
-		
+		const std::string& pretty() const&;
+
+		/// Returns pretty-print address.
+		std::string&& pretty() &&;
+
 		/// Returns binary address.
 		const uint8_t* data() const;
 		

--- a/include/nemcpp/service/read_result.h
+++ b/include/nemcpp/service/read_result.h
@@ -17,10 +17,7 @@ namespace nem2_sdk {
 	class ReadResult {
 	public:
 		/// Creates result.
-		ReadResult(ReadResultCode code, size_t consumed, const std::string& description = {});
-		
-		/// Creates result.
-		//ReadResult(ReadResultCode code, size_t consumed, std::string_view description = {});
+		ReadResult(ReadResultCode code, size_t consumed, std::string_view description = {});
 		
 		/// Returns read operation result code.
 		ReadResultCode code() const;

--- a/include/nemcpp/traits.h
+++ b/include/nemcpp/traits.h
@@ -1,6 +1,8 @@
 
 #pragma once
 
+#include <nemcpp/utils/hashable_array.h>
+
 #include <type_traits>
 #include <utility>
 
@@ -13,6 +15,16 @@ namespace nem2_sdk {
 		return static_cast<std::underlying_type_t<TEnum>>(value);
 	}
 	
+	/// Determines whether \c T is specialization of template type \c U.
+	template<typename T, template<typename...> typename U>
+	struct is_specialization: std::false_type { };
+
+	template<template<typename...> typename U, typename... TArgs>
+	struct is_specialization<U<TArgs...>, U>: std::true_type { };
+
+	template<typename T, template<typename...> typename U>
+	constexpr bool is_specialization_v = is_specialization<T, U>::value;
+
 	/// Determines whether \c T represents some container (type that has methods \c data and \c size).
 	template<typename T>
 	struct is_container {
@@ -46,4 +58,17 @@ namespace nem2_sdk {
 	
 	template<typename T>
 	constexpr bool is_iterable_v = is_iterable<T>::value;
+
+	/// Determines whether \c T is an \c std::array or \c HashableArray.
+	template<typename T>
+	struct is_array: public std::false_type { };
+
+	template<typename TItem, size_t N>
+	struct is_array<std::array<TItem, N>>: public std::true_type { };
+
+	template<typename TItem, size_t N>
+	struct is_array<HashableArray<TItem, N>>: public std::true_type { };
+
+	template<typename T>
+	constexpr bool is_array_v = is_array<T>::value;
 }

--- a/include/nemcpp/traits.h
+++ b/include/nemcpp/traits.h
@@ -30,13 +30,13 @@ namespace nem2_sdk {
 	struct is_container {
 		template<
 			typename U,
-			typename = typename std::enable_if<std::is_pointer_v<decltype(std::declval<U*>()->data())>>::type,
-			typename = decltype(std::declval<U*>()->size())>
+			typename = typename std::enable_if<std::is_pointer_v<decltype(std::declval<U&>().data())>>::type,
+			typename = decltype(std::declval<U&>().size())>
 		static std::true_type test(int);
 		
 		template<typename U> static std::false_type test(...);
 		
-		static constexpr bool value = decltype(test<typename std::decay<T>::type>(0))::value;
+		static constexpr bool value = decltype(test<std::decay_t<T>>(0))::value;
 	};
 	
 	template<typename T>
@@ -47,28 +47,28 @@ namespace nem2_sdk {
 	struct is_iterable {
 		template<
 			typename U,
-			typename = decltype(std::declval<U*>()->begin()),
-			typename = decltype(std::declval<U*>()->end())>
-		static std::true_type test(int);
-		
+			typename = decltype(std::begin(std::declval<U&>())),
+			typename = decltype(std::end(std::declval<U&>()))>
+			static std::true_type test(int);
+
 		template<typename U> static std::false_type test(...);
-		
-		static constexpr bool value = decltype(test<typename std::decay<T>::type>(0))::value;
+
+		static constexpr bool value = decltype(test<std::remove_cv_t<std::remove_reference_t<T>>>(0))::value;
 	};
-	
+
 	template<typename T>
 	constexpr bool is_iterable_v = is_iterable<T>::value;
 
 	/// Determines whether \c T is an \c std::array or \c HashableArray.
 	template<typename T>
-	struct is_array: public std::false_type { };
+	struct is_array_ext: public std::false_type { };
 
 	template<typename TItem, size_t N>
-	struct is_array<std::array<TItem, N>>: public std::true_type { };
+	struct is_array_ext<std::array<TItem, N>>: public std::true_type { };
 
 	template<typename TItem, size_t N>
-	struct is_array<HashableArray<TItem, N>>: public std::true_type { };
+	struct is_array_ext<HashableArray<TItem, N>>: public std::true_type { };
 
 	template<typename T>
-	constexpr bool is_array_v = is_array<T>::value;
+	constexpr bool is_array_ext_v = is_array_ext<T>::value;
 }

--- a/include/nemcpp/utils/buffer.h
+++ b/include/nemcpp/utils/buffer.h
@@ -180,7 +180,7 @@ namespace nem2_sdk {
 		constexpr ElementType* convertData(TSomeElement* data)
 		{
 			static_assert(is_convertible_v<std::remove_cv_t<TSomeElement>, std::remove_cv_t<ElementType>>,
-			              "can't perform implicit conversion");
+			              "can't perform implicit conversion to buffer element type");
 			
 			if constexpr (std::is_same_v<ElementType, TSomeElement>) {
 				// reinterpret_cast is not allowed in constexpr function, avoiding it if possible
@@ -195,7 +195,7 @@ namespace nem2_sdk {
 		constexpr size_t convertSize(size_t size)
 		{
 			static_assert(is_convertible_v<std::remove_cv_t<TSomeElement>, std::remove_cv_t<ElementType>>,
-			              "can't perform implicit conversion");
+			              "can't perform implicit conversion to buffer element type");
 			return size * (sizeof(TSomeElement) / sizeof(ElementType));
 		}
 		

--- a/include/nemcpp/utils/format.h
+++ b/include/nemcpp/utils/format.h
@@ -3,6 +3,8 @@
 
 #include <nemcpp/traits.h>
 
+#include <algorithm>
+#include <array>
 #include <cstdio>
 #include <sstream>
 #include <string>
@@ -134,7 +136,7 @@ namespace nem2_sdk {
 	
 	/// Converts hex-formatted string to binary vector \a data and returns \c true on success.
 	template<typename T>
-	bool FromHex(std::string_view hexStr, std::vector<T>& data)
+	auto FromHex(std::string_view hexStr, std::vector<T>& data)	-> std::enable_if_t<std::is_integral_v<T> || std::is_enum_v<T>, bool>
 	{
 		data.clear();
 		size_t itemLen = sizeof(T) * 2;
@@ -154,6 +156,20 @@ namespace nem2_sdk {
 			}
 		}
 		
+		return true;
+	}
+
+	/// Converts hex-formatted string to an array \a data and returns \c true on success.
+	template<typename T, size_t N>
+	auto FromHex(std::string_view hexStr, std::array<T, N>& data) -> std::enable_if_t<std::is_integral_v<T> || std::is_enum_v<T>, bool>
+	{
+		std::vector<T> buf;
+
+		if (!FromHex(hexStr, buf) || buf.size() != N) {
+			return false;
+		}
+
+		std::copy(buf.begin(), buf.end(), data.begin());
 		return true;
 	}
 }

--- a/include/nemcpp/utils/format.h
+++ b/include/nemcpp/utils/format.h
@@ -136,7 +136,7 @@ namespace nem2_sdk {
 	template<typename T>
 	bool FromHex(std::string_view hexStr, std::vector<T>& data)
 	{
-			data.clear();
+		data.clear();
 		size_t itemLen = sizeof(T) * 2;
 		
 		if (hexStr.empty()) {

--- a/include/nemcpp/utils/format.h
+++ b/include/nemcpp/utils/format.h
@@ -21,7 +21,10 @@ namespace nem2_sdk {
 			stream_ << arg;
 			return *this;
 		}
-		
+
+		/// Returns builded string
+		std::string str() const;
+
 		/// Returns builded string.
 		operator std::string() const;
 		

--- a/include/nemcpp/utils/lazy.h
+++ b/include/nemcpp/utils/lazy.h
@@ -18,20 +18,20 @@ namespace nem2_sdk {
 	class Lazy {
 	public:
 		/// User-defined type.
-		using Type = TType;
+		using ClassType = TType;
 		
 		/// User-defined type data member type.
 		using MemberType = TMemberType;
 		
 	public:
 		/// Creates wrapper for lazy-initialized data member of \a obj using \a value as initial value.
-		explicit Lazy(Type* obj, const std::optional<MemberType>& value = std::nullopt):
+		explicit Lazy(ClassType* obj, const std::optional<MemberType>& value = std::nullopt):
 			initialize_(std::bind(initialize, obj, std::placeholders::_1)),
 			value_(value)
 		{ }
 		
 		/// Creates wrapper for lazy-initialized data member of \a obj using \a value as initial value.
-		explicit Lazy(Type* obj, std::optional<MemberType>&& value):
+		explicit Lazy(ClassType* obj, std::optional<MemberType>&& value):
 			initialize_(std::bind(initialize, obj, std::placeholders::_1)),
 			value_(std::move(value))
 		{ }

--- a/include/nemcpp/utils/lazy.h
+++ b/include/nemcpp/utils/lazy.h
@@ -57,7 +57,7 @@ namespace nem2_sdk {
 		/// Sets wrapped value.
 		template<
 			typename T,
-			typename = typename std::enable_if<std::is_constructible_v<MemberType, T&&>>::type>
+			typename = typename std::enable_if<std::is_assignable_v<MemberType, T&&>>::type>
 		Lazy& operator=(T&& value)
 		{
 			value_ = std::forward<T>(value);
@@ -73,7 +73,7 @@ namespace nem2_sdk {
 		}
 		
 		/// Returns wrapped value initializing it if necessary.
-		MemberType& value()
+		MemberType& value() &
 		{
 			if (!value_) {
 				initialize_(value_);
@@ -83,7 +83,7 @@ namespace nem2_sdk {
 		}
 		
 		/// Returns wrapped value initializing it if necessary.
-		const MemberType& value() const
+		const MemberType& value() const&
 		{
 			if (!value_) {
 				initialize_(value_);
@@ -91,19 +91,51 @@ namespace nem2_sdk {
 			
 			return *value_;
 		}
-		
+
 		/// Returns wrapped value initializing it if necessary.
-		MemberType& operator*()
+		MemberType&& value() &&
+		{
+			if (!value_) {
+				initialize_(value_);
+			}
+
+			return *std::move(value_);
+		}
+
+		/// Returns wrapped value initializing it if necessary.
+		const MemberType&& value() const&&
+		{
+			if (!value_) {
+				initialize_(value_);
+			}
+
+			return *std::move(value_);
+		}
+
+		/// Returns wrapped value initializing it if necessary.
+		MemberType& operator*() &
 		{
 			return value();
 		}
 		
 		/// Returns wrapped value initializing it if necessary.
-		const MemberType& operator*() const
+		const MemberType& operator*() const&
 		{
 			return value();
 		}
-		
+
+		/// Returns wrapped value initializing it if necessary.
+		MemberType&& operator*() &&
+		{
+			return std::move(*this).value();
+		}
+
+		/// Returns wrapped value initializing it if necessary.
+		const MemberType&& operator*() const&&
+		{
+			return std::move(*this).value();
+		}
+
 		/// Returns wrapped value initializing it if necessary.
 		MemberType* operator->()
 		{

--- a/src/infrastructure/binary/descriptors.h
+++ b/src/infrastructure/binary/descriptors.h
@@ -13,31 +13,25 @@ namespace nem2_sdk { namespace internal { namespace binary {
 		
 		template<typename TName>
 		struct VariableSize {
+			using SizeFieldName = TName;
+
 			template<typename... TFields>
 			static size_t GetSize(const VariadicStruct<TFields...>& obj)
 			{
-				using Traits = struct_field_by_name<TName, VariadicStruct<TFields...>>;
-				
-				if constexpr (std::is_integral_v<typename Traits::ValueType>) {
-					return static_cast<size_t>(obj.template value<Traits::Id()>());
-				} else {
-					static_assert(sizeof(TName) == 0, "invalid size field type");
-				}
+				using Traits = struct_field_by_name<SizeFieldName, VariadicStruct<TFields...>>;
+				return static_cast<size_t>(obj.template value<Traits::Id()>());
 			}
 		};
 		
 		template<typename TName>
 		struct TrailingSize {
+			using SizeFieldName = TName;
+
 			template<typename... TFields>
 			static size_t GetTotalSize(const VariadicStruct<TFields...>& obj)
 			{
-				using Traits = struct_field_by_name<TName, VariadicStruct<TFields...>>;
-				
-				if constexpr (std::is_integral_v<typename Traits::ValueType>) {
-					return static_cast<size_t>(obj.template value<Traits::Id()>());
-				} else {
-					static_assert(sizeof(TName) == 0, "invalid total size field type");
-				}
+				using Traits = struct_field_by_name<SizeFieldName, VariadicStruct<TFields...>>;
+				return static_cast<size_t>(obj.template value<Traits::Id()>());
 			}
 		};
 		

--- a/src/infrastructure/binary/descriptors.h
+++ b/src/infrastructure/binary/descriptors.h
@@ -34,17 +34,23 @@ namespace nem2_sdk { namespace internal { namespace binary {
 				return static_cast<size_t>(obj.template value<Traits::Id()>());
 			}
 		};
-		
-		template<typename>
-		constexpr bool is_variable_size_v = false;
-		
-		template<typename TName>
-		constexpr bool is_variable_size_v<VariableSize<TName>> = true;
-		
-		template<typename>
-		constexpr bool is_trailing_size_v = false;
+
+		template<typename T>
+		struct is_variable_size: public std::false_type { };
 		
 		template<typename TName>
-		constexpr bool is_trailing_size_v<TrailingSize<TName>> = true;
+		struct is_variable_size<VariableSize<TName>>: public std::true_type { };
+
+		template<typename T>
+		constexpr bool is_variable_size_v = is_variable_size<T>::value;
+
+		template<typename T>
+		struct is_trailing_size: public std::false_type { };
+
+		template<typename TName>
+		struct is_trailing_size<TrailingSize<TName>>: public std::true_type { };
+
+		template<typename T>
+		constexpr bool is_trailing_size_v = is_trailing_size<T>::value;
 	}
 }}}

--- a/src/infrastructure/binary/dto/transaction_dto.h
+++ b/src/infrastructure/binary/dto/transaction_dto.h
@@ -22,13 +22,7 @@
 
 namespace nem2_sdk { namespace internal { namespace binary {
 	
-	// Binary DTOs should contain only following types:
-	//
-	// 1. arithmetic (int, double, etc) and enums
-	// 2. std::array which has fixed size
-	// 3. std::string which requires size descriptor and treats it as string length
-	// 4. std::vector which requires size descriptor and treats it as elements count
-	// 5. other binary DTOs
+	// See ../parser.h for description of supported variadic struct field types and descriptors.
 	
 	// Common DTOs
 	//==========================================================================

--- a/src/infrastructure/binary/parser.h
+++ b/src/infrastructure/binary/parser.h
@@ -19,11 +19,11 @@ namespace nem2_sdk { namespace internal { namespace binary {
 	
 	// Binary DTOs should contain only following types:
 	//
-	// 1. arithmetic (int, double, etc) and enums
-	// 2. std::array or nem2_sdk::HashableArray which have fixed size
-	// 3. std::string which requires size descriptor and treats it as string length
-	// 4. std::vector which requires size descriptor and treats it as elements count
-	// 5. other binary DTOs
+	// 1. other DTOs with null (void) descriptor and fields of types 1-5
+	// 2. integral (int, short, etc) and enums with null (void) descriptor
+	// 3. std::array or nem2_sdk::HashableArray with elements of type 1-3 and null (void) descriptor
+	// 4. std::vector with elements of type 1-3 and VariableSize or TrailingSize descriptor used for vector size calculation
+	// 5. std::string with VariableSize or TrailingSize descriptor used for string size calculation
 	
 	class ParseResult {
 	public:
@@ -88,9 +88,48 @@ namespace nem2_sdk { namespace internal { namespace binary {
 		}
 		
 	private:
+		template<typename TName, typename TStruct, typename TField, typename TDescriptor, bool IsItem = false>
+		static constexpr void CheckField()
+		{
+			if constexpr (std::is_integral_v<TField> || std::is_enum_v<TField> || is_array_v<TField> || is_variadic_struct_v<TField>) {
+				if constexpr (!std::is_same_v<TDescriptor, void>) {
+					static_assert(sizeof(TField) == 0, "invalid field descriptor (should be void)");
+				}
+
+				if constexpr (is_array_v<TField>) {
+					CheckField<TName, TStruct, typename TField::value_type, void, true>();
+				}
+			} else if constexpr (!IsItem && (is_specialization_v<TField, std::vector> || std::is_same_v<TField, std::string>)) {
+				if constexpr (desc::is_variable_size_v<TDescriptor> || desc::is_trailing_size_v<TDescriptor>) {
+					if constexpr (!has_field_by_name<typename TDescriptor::SizeFieldName, TStruct>::value) {
+						static_assert(sizeof(TField) == 0, "unknown size field name");
+					} else if constexpr (!std::is_integral_v<typename struct_field_by_name<typename TDescriptor::SizeFieldName, TStruct>::ValueType>) {
+						static_assert(sizeof(TField) == 0, "invalid size field type (should be integral)");
+					}
+				} else {
+					static_assert(sizeof(TField) == 0, "invalid container field descriptor (should be 'VariableSize' or 'TrailingSize')");
+				}
+
+				if constexpr (is_specialization_v<TField, std::vector>) {
+					return CheckField<TName, TStruct, typename TField::value_type, void, true>();
+				}
+			} else {
+				if constexpr (IsItem) {
+					static_assert(sizeof(TField) == 0, "invalid container field item type");
+				} else {
+					static_assert(sizeof(TField) == 0, "invalid field type");
+				}
+			}
+		}
+
 		template<typename TStruct, size_t... Idx>
 		static bool ReadStruct(TStruct& obj, ReadOnlyByteStream& bs, std::index_sequence<Idx...>)
 		{
+			(CheckField<typename struct_field_by_index<Idx, TStruct>::NameType,
+			            TStruct,
+			            typename struct_field_by_index<Idx, TStruct>::ValueType,
+			            typename struct_field_by_index<Idx, TStruct>::DescriptorType>(), ...);
+
 			auto result =
 				(Impl<typename struct_field_by_index<Idx, TStruct>::ValueType>::template Read<typename struct_field_by_index<Idx, TStruct>::DescriptorType>(
 				     obj, obj.template value<Field_Id<Idx, TStruct>>(), bs)
@@ -106,6 +145,11 @@ namespace nem2_sdk { namespace internal { namespace binary {
 		template<typename TStruct, size_t... Idx>
 		static bool WriteStruct(const TStruct& obj, ByteStream& bs, std::index_sequence<Idx...>)
 		{
+			(CheckField<typename struct_field_by_index<Idx, TStruct>::NameType,
+				TStruct,
+				typename struct_field_by_index<Idx, TStruct>::ValueType,
+				typename struct_field_by_index<Idx, TStruct>::DescriptorType>(), ...);
+
 			bool isAllSet = (obj.template isSet<Field_Id<Idx, TStruct>>() && ...);
 			
 			if (!isAllSet) {
@@ -118,6 +162,11 @@ namespace nem2_sdk { namespace internal { namespace binary {
 		template<typename TStruct, size_t... Idx>
 		static size_t CalculateStructSize(const TStruct& obj, std::index_sequence<Idx...>)
 		{
+			(CheckField<typename struct_field_by_index<Idx, TStruct>::NameType,
+				TStruct,
+				typename struct_field_by_index<Idx, TStruct>::ValueType,
+				typename struct_field_by_index<Idx, TStruct>::DescriptorType>(), ...);
+
 			if constexpr (struct_size<TStruct>::value) {
 				return (Impl<typename struct_field_by_index<Idx, TStruct>::ValueType>::CalculateSize(obj.template value<Field_Id<Idx, TStruct>>()) + ...);
 			} else {
@@ -160,13 +209,23 @@ namespace nem2_sdk { namespace internal { namespace binary {
 			template<typename TSizeDescriptor, typename TStruct>
 			static bool Read(TStruct&, TField& field, ReadOnlyByteStream& bs)
 			{
-				bs >> field;
-				return static_cast<bool>(bs);
-			}
+				if constexpr (std::is_integral_v<TField> || std::is_enum_v<TField>) {
+					bs >> field;
+				} else {
+					static_assert(sizeof(TField) == 0, "field type is not supported by binary parser");
+				}
+
+				return static_cast<bool>(bs);			}
 			
+			template<typename TUnused = void> // without this some of 'CheckField' asserts can be skipped
 			static bool Write(const TField& field, ByteStream& bs)
 			{
-				bs << field;
+				if constexpr (std::is_integral_v<TField> || std::is_enum_v<TField>) {
+					bs << field;
+				} else {
+					static_assert(sizeof(TField) == 0, "field type is not supported by binary parser");
+				}
+
 				return true;
 			}
 			
@@ -243,7 +302,7 @@ namespace nem2_sdk { namespace internal { namespace binary {
 					field.push_back(item);
 				}
 			} else {
-				static_assert(sizeof(TSizeDescriptor) == 0, "invalid binary field size descriptor");
+				static_assert(sizeof(TStruct) == 0, "binary parser unable to determine container field size");
 			}
 			
 			return static_cast<bool>(bs);
@@ -277,7 +336,7 @@ namespace nem2_sdk { namespace internal { namespace binary {
 				field.resize(size);
 				bs >> field;
 			} else {
-				static_assert(sizeof(TSizeDescriptor) == 0, "invalid binary field size descriptor");
+				static_assert(sizeof(TStruct) == 0, "binary parser unable to determine container field size");
 			}
 			
 			return static_cast<bool>(bs);

--- a/src/infrastructure/json/descriptors.h
+++ b/src/infrastructure/json/descriptors.h
@@ -1,12 +1,47 @@
 
 #pragma once
 
+#include <nemcpp/utils/bitwise_enum.h>
+
+#include <type_traits>
+
 namespace nem2_sdk { namespace internal { namespace json {
 	
 	namespace desc {
 		
 		// This namespace contains json field descriptors.
 		
-		struct Optional {};
+		enum class FieldFlags: uint8_t {
+			None = 0x00,
+			Optional = 0x01,
+			All = 0x01
+		};
+
+		NEM2_SDK_BITWISE_ENUM(FieldFlags);
+
+		template<FieldFlags Value>
+		using Flags = std::integral_constant<FieldFlags, Value>;
+
+		template<typename T>
+		struct is_field_flags: public std::false_type { };
+
+		template<FieldFlags Value>
+		struct is_field_flags<std::integral_constant<FieldFlags, Value>>: public std::true_type { };
+
+		template<typename T>
+		constexpr bool is_field_flags_v = is_field_flags<T>::value;
+
+		template<typename T>
+		constexpr FieldFlags GetFieldFlags()
+		{
+			if constexpr (is_field_flags_v<T>) {
+				return T::value;
+			} else {
+				return FieldFlags::None;
+			}
+		}
+
+		template<typename T>
+		constexpr bool Is_Optional = CheckAll(GetFieldFlags<T>(), FieldFlags::Optional);
 	}
 }}}

--- a/src/infrastructure/json/dto/mosaic_dto.h
+++ b/src/infrastructure/json/dto/mosaic_dto.h
@@ -2,11 +2,18 @@
 #pragma once
 
 #include "infrastructure/json/uint64.h"
+#include "infrastructure/utils/variadic_struct.h"
+
+#include <nemcpp/model/mosaic/mosaic_property.h>
 
 namespace nem2_sdk { namespace internal { namespace json {
 	
+	// See ../parser.h for description of supported variadic struct field types and descriptors.
+
+	using MosaicIdDTO = Uint64;
+
 	using MosaicDTO = VariadicStruct<
-		Field<STR_LITERAL("id"),     Uint64>,
+		Field<STR_LITERAL("id"),     MosaicIdDTO>,
 		Field<STR_LITERAL("amount"), Uint64>>;
 	
 	using MosaicPropertyDTO = VariadicStruct<

--- a/src/infrastructure/json/hex.h
+++ b/src/infrastructure/json/hex.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <utility>
+
+namespace nem2_sdk { namespace internal { namespace json { 
+
+	template<typename T>
+	class Hex {
+	public:
+		using WrappedType = T;
+	
+	public:
+		Hex() = default;
+
+		Hex(const WrappedType& data) : data_(data)
+		{ }
+
+		Hex(WrappedType&& data) : data_(std::move(data))
+		{ }
+
+		WrappedType& unwrap() &
+		{ return data_;	}
+
+		const WrappedType& unwrap() const &
+		{ return data_; }
+
+		WrappedType&& unwrap() &&
+		{ return std::move(data_); }
+
+		const WrappedType&& unwrap() const &&
+		{ return std::move(data_); }
+
+		operator WrappedType&() &
+		{ return unwrap(); }
+
+		operator const WrappedType&() const &
+		{ return unwrap(); }
+
+		operator WrappedType&&() &&
+		{ return std::move(*this).unwrap(); }
+
+		operator const WrappedType&&() const &&
+		{ return std::move(*this).unwrap(); }
+
+		Hex& operator=(const WrappedType& data)
+		{
+			data_ = data;
+			return *this;
+		}
+
+		Hex& operator=(WrappedType&& data)
+		{
+			data_ = std::move(data);
+			return *this;
+		}
+
+	private:
+		WrappedType data_;
+	};
+}}}

--- a/src/infrastructure/json/parser.h
+++ b/src/infrastructure/json/parser.h
@@ -133,7 +133,18 @@ namespace nem2_sdk { namespace internal { namespace json {
 					return true;
 				}
 				
-				if constexpr (std::is_integral_v<TField>) {
+				if constexpr (std::is_enum_v<TField>) {
+					using Type = std::underlying_type_t<TField>;
+					Type rawValue = Type{};
+
+					auto result = Impl<Type>::Read(rawValue, jsonValue, jsonPtr);
+
+					if (result) {
+						value = static_cast<TField>(rawValue);
+					}
+					
+					return result;
+				} else if constexpr (std::is_integral_v<TField>) {
 					if constexpr (std::is_same_v<TField, bool>) {
 						if (jsonValue->IsBool()) {
 							value = jsonValue->GetBool();
@@ -180,7 +191,10 @@ namespace nem2_sdk { namespace internal { namespace json {
 			                         const char* jsonPtr,
 			                         rapidjson::Document& document)
 			{
-				if constexpr (std::is_integral_v<TField>) {
+				if constexpr (std::is_enum_v<TField>) {
+					using Type = std::underlying_type_t<TField>;
+					return Impl<Type>::Write(static_cast<Type>(value), jsonValue, jsonPtr, document);
+				} else if constexpr (std::is_integral_v<TField>) {
 					if constexpr (std::is_same_v<TField, bool>) {
 						jsonValue.SetBool(value);
 					} else if constexpr (std::is_unsigned_v<TField>) {

--- a/src/infrastructure/json/parser.h
+++ b/src/infrastructure/json/parser.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "infrastructure/json/descriptors.h"
+#include "infrastructure/json/hex.h"
 #include "infrastructure/json/uint64.h"
 #include "infrastructure/utils/variadic_struct.h"
 

--- a/src/infrastructure/json/parser.h
+++ b/src/infrastructure/json/parser.h
@@ -23,7 +23,17 @@
 #include <vector>
 
 namespace nem2_sdk { namespace internal { namespace json {
-	
+
+	// Json DTOs should contain only following types:
+	//
+	// 1. other DTOs
+	// 2. arithmetic (int, double (but no float!) etc), enums and special type Uint64 which is represented
+	//    in json as 2 item array holding low and high 32bit parts of 64bit value
+	// 3. std::vector, std::array or nem2_sdk::HashableArray with elements of any supported type
+	// 4. std::string
+	// 5. special template type 'Hex<T>' which marks wrapped type as hex-formatted in json; type T can be
+	//    integral, enum or any of the container type from 3 if their value type is integral or enum.
+
 	enum class OutputMode: uint8_t {
 		Default = 0,
 		Pretty

--- a/src/infrastructure/json/parser.h
+++ b/src/infrastructure/json/parser.h
@@ -331,7 +331,7 @@ namespace nem2_sdk { namespace internal { namespace json {
 		                        const char* jsonPtr,
 		                        std::index_sequence<Idx...>)
 		{
-			ParseResult result = { true, "" };
+			ParseResult result = true;
 			
 			( ( result = ReadField<struct_field_by_index<Idx, StructType>>(value, jsonValue, jsonPtr),
 			    result ) && ... );
@@ -390,7 +390,7 @@ namespace nem2_sdk { namespace internal { namespace json {
 		                              rapidjson::Document& document)
 		{
 			std::string fieldPtr = MakeString{} << jsonPtr << "/" << TTraits::Name();
-			std::pair<bool, std::string> result = { true, "" };
+			ParseResult result = true;
 			
 			if (obj.template isSet<TTraits::Id()>()) {
 				rapidjson::Value memberName(TTraits::Name(), document.GetAllocator());

--- a/src/infrastructure/json/parser.h
+++ b/src/infrastructure/json/parser.h
@@ -121,6 +121,41 @@ namespace nem2_sdk { namespace internal { namespace json {
 			
 			return result;
 		}
+
+	private:
+		template<typename TName, typename TStruct, typename TField, typename TDescriptor = void>
+		static constexpr bool IsValidField() // bool return value to force compiler to instantiate this function template early
+		{
+			if constexpr (!desc::is_field_flags_v<TDescriptor> && !std::is_same_v<TDescriptor, void>) {
+				static_assert(sizeof(TField) == 0, "invalid field descriptor (should be void or 'Flags')");
+			}
+
+			if constexpr ( (std::is_arithmetic_v<TField> && !std::is_same_v<TField, float>) ||
+			               std::is_enum_v<TField> ||
+			               std::is_same_v<TField, std::string> ||
+			               std::is_same_v<TField, Uint64> ||
+			               is_variadic_struct_v<TField>) {
+				//do nothing
+			} else if constexpr (is_specialization_v<TField, std::vector> || is_array_ext_v<TField>) {
+				return IsValidField<TName, TStruct, typename TField::value_type>();
+			} else if constexpr (is_specialization_v<TField, Hex>) {
+				if constexpr (std::is_integral_v<typename TField::WrappedType> || std::is_enum_v<typename TField::WrappedType>) {
+					//do nothing
+				} else if constexpr (is_specialization_v<typename TField::WrappedType, std::vector> ||
+				                     is_array_ext_v<typename TField::WrappedType>) {
+					if constexpr  (!std::is_integral_v<typename TField::WrappedType::value_type> &&
+					               !std::is_enum_v<typename TField::WrappedType::value_type>) {
+						static_assert(sizeof(TField) == 0, "invalid wrapped type for hex-formatted field");
+					}
+				} else {
+					static_assert(sizeof(TField) == 0, "invalid wrapped type for hex-formatted field");
+				}
+			} else {
+				static_assert(sizeof(TField) == 0, "invalid field type");
+			}
+
+			return true;
+		}
 		
 	private:
 		template<typename TField>
@@ -134,10 +169,8 @@ namespace nem2_sdk { namespace internal { namespace json {
 				}
 				
 				if constexpr (std::is_enum_v<TField>) {
-					using Type = std::underlying_type_t<TField>;
-					Type rawValue = Type{};
-
-					auto result = Impl<Type>::Read(rawValue, jsonValue, jsonPtr);
+					std::underlying_type_t<TField> rawValue{};
+					auto result = Impl<std::underlying_type_t<TField>>::Read(rawValue, jsonValue, jsonPtr);
 
 					if (result) {
 						value = static_cast<TField>(rawValue);
@@ -180,7 +213,7 @@ namespace nem2_sdk { namespace internal { namespace json {
 						return true;
 					}
 				} else {
-					static_assert(sizeof(TField) == 0, "type is not supported by json parser");
+					static_assert(sizeof(TField) == 0, "field type is not supported by json parser");
 				}
 				
 				return { false, jsonPtr };
@@ -192,8 +225,7 @@ namespace nem2_sdk { namespace internal { namespace json {
 			                         rapidjson::Document& document)
 			{
 				if constexpr (std::is_enum_v<TField>) {
-					using Type = std::underlying_type_t<TField>;
-					return Impl<Type>::Write(static_cast<Type>(value), jsonValue, jsonPtr, document);
+					return Impl<std::underlying_type_t<TField>>::Write(to_underlying_type(value), jsonValue, jsonPtr, document);
 				} else if constexpr (std::is_integral_v<TField>) {
 					if constexpr (std::is_same_v<TField, bool>) {
 						jsonValue.SetBool(value);
@@ -207,7 +239,7 @@ namespace nem2_sdk { namespace internal { namespace json {
 				} else if constexpr (std::is_same_v<TField, std::string>) {
 					jsonValue.SetString(value.c_str(), document.GetAllocator());
 				} else {
-					static_assert(sizeof(TField) == 0, "type is not supported by json parser");
+					static_assert(sizeof(TField) == 0, "field type is not supported by json parser");
 				}
 				
 				return true;
@@ -219,7 +251,7 @@ namespace nem2_sdk { namespace internal { namespace json {
 	};
 	
 	// Implementation specializations for complex types
-	
+
 	template<typename TItem>
 	class Parser::Impl<std::vector<TItem>> {
 	public:
@@ -237,7 +269,7 @@ namespace nem2_sdk { namespace internal { namespace json {
 			
 			for (decltype(size) i = 0; i < size; ++i) {
 				std::string itemPtr = MakeString{} << jsonPtr << "/" << i;
-				TItem item;
+				TItem item{};
 				
 				auto result = Impl<TItem>::Read(item, &(*jsonValue)[i], itemPtr.c_str());
 				
@@ -288,7 +320,7 @@ namespace nem2_sdk { namespace internal { namespace json {
 			}
 			
 			std::vector<TItem> data;
-			auto result = Impl<decltype(data)>::Read(data, jsonValue, jsonPtr);
+			auto result = Impl<std::vector<TItem>>::Read(data, jsonValue, jsonPtr);
 			
 			if (result) {
 				std::copy(data.begin(), data.end(), value.begin());
@@ -304,13 +336,43 @@ namespace nem2_sdk { namespace internal { namespace json {
 		{
 			std::vector<TItem> data;
 			std::copy(value.begin(), value.end(), std::back_inserter(data));
-			return Impl<decltype(data)>::Write(data, jsonValue, jsonPtr, document);
+			return Impl<std::vector<TItem>>::Write(data, jsonValue, jsonPtr, document);
 		}
 	};
 	
 	template<typename TItem, size_t N>
 	class Parser::Impl<HashableArray<TItem, N>>: public Parser::Impl<std::array<TItem, N>> { };
 	
+	template<typename TWrappedType>
+	class Parser::Impl<Hex<TWrappedType>> {
+	public:
+		static ParseResult Read(Hex<TWrappedType>& value, const rapidjson::Value* jsonValue, const char* jsonPtr)
+		{
+			if (!jsonValue || jsonValue->IsNull()) {
+				value = TWrappedType{};
+				return true;
+			}
+
+			std::string hexData;
+			auto result = Impl<std::string>::Read(hexData, jsonValue, jsonPtr);
+
+			if (result && !FromHex(hexData, value.unwrap())) {
+				result = { false, jsonPtr };
+			}
+
+			return result;
+		}
+
+		static ParseResult Write(const Hex<TWrappedType>& value,
+		                         rapidjson::Value& jsonValue,
+		                         const char* jsonPtr,
+		                         rapidjson::Document& document)
+		{
+			std::string hexData = ToHex(value.unwrap());
+			return Impl<std::string>::Write(hexData, jsonValue, jsonPtr, document);
+		}
+	};
+
 	template<typename... TFields>
 	class Parser::Impl<VariadicStruct<TFields...>> {
 	public:
@@ -346,12 +408,21 @@ namespace nem2_sdk { namespace internal { namespace json {
 		                        const char* jsonPtr,
 		                        std::index_sequence<Idx...>)
 		{
-			ParseResult result = true;
-			
-			( ( result = ReadField<struct_field_by_index<Idx, StructType>>(value, jsonValue, jsonPtr),
-			    result ) && ... );
-			
-			return result;
+			constexpr bool isValidStruct = (IsValidField<typename struct_field_by_index<Idx, StructType>::NameType,
+			                                             StructType,
+			                                             typename struct_field_by_index<Idx, StructType>::ValueType,
+			                                             typename struct_field_by_index<Idx, StructType>::DescriptorType>() && ...);
+
+			if constexpr (isValidStruct) {
+				ParseResult result = true;
+
+				( ( result = ReadField<struct_field_by_index<Idx, StructType>>(value, jsonValue, jsonPtr),
+				    result ) && ... );
+
+				return result;
+			} else {
+				static_assert(sizeof...(Idx) < 0, "variadic struct is not supported by json parser");
+			}
 		}
 		
 		template<size_t... Idx>
@@ -361,12 +432,20 @@ namespace nem2_sdk { namespace internal { namespace json {
 		                         rapidjson::Document& document,
 		                         std::index_sequence<Idx...>)
 		{
-			ParseResult result = true;
-			
-			( ( result = WriteField<struct_field_by_index<Idx, StructType>>(value, jsonValue, jsonPtr, document),
-			    result ) && ... );
-			
-			return result;
+			constexpr bool isValidStruct = (IsValidField<typename struct_field_by_index<Idx, StructType>::NameType,
+			                                             StructType,
+			                                             typename struct_field_by_index<Idx, StructType>::ValueType,
+			                                             typename struct_field_by_index<Idx, StructType>::DescriptorType>() && ...);
+
+			if constexpr (isValidStruct) {
+				ParseResult result = true;
+
+				( ( result = WriteField<struct_field_by_index<Idx, StructType>>(value, jsonValue, jsonPtr, document),
+				    result ) && ... );
+				return result;
+			} else {
+				static_assert(sizeof...(Idx) < 0, "variadic struct is not supported by json parser");
+			}
 		}
 		
 		template<typename TTraits, typename TStruct>
@@ -386,7 +465,7 @@ namespace nem2_sdk { namespace internal { namespace json {
 			if (result) {
 				bool isSet = it != jsonValue->MemberEnd() && !(it->value.IsNull());
 				
-				if constexpr (!std::is_same_v<typename TTraits::DescriptorType, desc::Optional>) {
+				if constexpr (!desc::Is_Optional<typename TTraits::DescriptorType>) {
 					if (!isSet) {
 						return { false, fieldPtr };
 					}
@@ -417,7 +496,7 @@ namespace nem2_sdk { namespace internal { namespace json {
 				if (result) {
 					jsonValue.AddMember(memberName.Move(), memberValue.Move(), document.GetAllocator());
 				}
-			} else if constexpr (!std::is_same_v<typename TTraits::DescriptorType, desc::Optional>) {
+			} else if constexpr (!desc::Is_Optional<typename TTraits::DescriptorType>) {
 				result = { false, fieldPtr };
 			}
 			
@@ -430,8 +509,8 @@ namespace nem2_sdk { namespace internal { namespace json {
 	public:
 		static ParseResult Read(Uint64& value, const rapidjson::Value* jsonValue, const char* jsonPtr)
 		{
-			std::array<uint32_t, 2> data;
-			auto result = Impl<decltype(data)>::Read(data, jsonValue, jsonPtr);
+			std::array<uint32_t, 2> data{};
+			auto result = Impl<std::array<uint32_t, 2>>::Read(data, jsonValue, jsonPtr);
 			
 			if (result) {
 				value = data[0];
@@ -447,10 +526,10 @@ namespace nem2_sdk { namespace internal { namespace json {
 		                         const char* jsonPtr,
 		                         rapidjson::Document& document)
 		{
-			std::array<uint32_t, 2> arr;
+			std::array<uint32_t, 2> arr{};
 			arr[0] = static_cast<uint32_t>(value >> 32);
 			arr[1] = static_cast<uint32_t>(value);
-			return Impl<decltype(arr)>::Write(arr, jsonValue, jsonPtr, document);
+			return Impl<std::array<uint32_t, 2>>::Write(arr, jsonValue, jsonPtr, document);
 		}
 	};
 }}}

--- a/src/infrastructure/json/uint64.h
+++ b/src/infrastructure/json/uint64.h
@@ -7,6 +7,7 @@ namespace nem2_sdk { namespace internal { namespace json {
 	
 	class Uint64 {
 	public:
+		Uint64() = default;
 		Uint64(uint64_t value);
 		operator uint64_t&();
 		operator const uint64_t&() const;

--- a/src/infrastructure/utils/variadic_struct.h
+++ b/src/infrastructure/utils/variadic_struct.h
@@ -12,7 +12,7 @@ namespace nem2_sdk { namespace internal {
 	template<typename TName, typename TValue, typename TDescriptor> class Field;
 	template<typename... TArgs> class VariadicStruct;
 	
-	template<typename> struct is_variadic_struct;
+	template<typename T> struct is_variadic_struct;
 	template<typename TStruct> struct struct_size;
 	template<typename TStruct> struct struct_parent;
 	template<uint64_t Id, typename TStruct> struct has_field_by_id;;
@@ -144,7 +144,7 @@ namespace nem2_sdk { namespace internal {
 				static_assert(sizeof(TArg) == 0, "argument can't be converted to variadic struct field value");
 			}
 			
-			using Type = typename std::decay<TArg>::type;
+			using Type = std::decay_t<TArg>;
 			bool result = true;
 			
 			if constexpr (std::is_arithmetic_v<Type> && std::is_arithmetic_v<TValue>) {
@@ -242,7 +242,7 @@ namespace nem2_sdk { namespace internal {
 			typename... TArgs,
 			typename = typename std::enable_if<sizeof...(TArgs) <= sizeof...(TFields)>::type,
 			typename = typename std::enable_if<sizeof...(TArgs) != 1 || // should not hide default copy and move!
-			                                   !(std::is_same_v<typename std::decay<TArgs>::type, SelfType> && ...)>::type>
+			                                   !(std::is_same_v<std::decay_t<TArgs>, SelfType> && ...)>::type>
 		constexpr VariadicStruct(TArgs&&... args):
 			VariadicStruct(std::tuple_cat(std::forward_as_tuple(std::forward<TArgs>(args)...),
 			                              make_tail(std::make_index_sequence<sizeof...(TFields) - sizeof...(TArgs)>{})),
@@ -294,7 +294,7 @@ namespace nem2_sdk { namespace internal {
 			typename... TArgs,
 			typename = typename std::enable_if<sizeof...(TArgs) <= struct_size<ParentType>::value + sizeof...(TFields)>::type,
 			typename = typename std::enable_if<sizeof...(TArgs) != 1 || // should not hide default copy and move!
-			                                   !(std::is_same_v<typename std::decay<TArgs>::type, SelfType> && ...)>::type>
+			                                   !(std::is_same_v<std::decay_t<TArgs>, SelfType> && ...)>::type>
 		constexpr VariadicStruct(TArgs&&... args):
 			VariadicStruct(std::tuple_cat(std::forward_as_tuple(std::forward<TArgs>(args)...),
 			                              make_tail(std::make_index_sequence<struct_size<ParentType>::value +
@@ -344,7 +344,7 @@ namespace nem2_sdk { namespace internal {
 	// Variadic struct traits.
 	//==========================================================================
 	
-	template<typename>
+	template<typename T>
 	struct is_variadic_struct: public std::false_type { };
 	
 	template<typename... TArgs>

--- a/src/sdk/model/account/account.cpp
+++ b/src/sdk/model/account/account.cpp
@@ -37,7 +37,7 @@ namespace nem2_sdk {
 	const PublicAccount& Account::publicAccount() const
 	{
 		if (!publicAccount_) {
-			requestPrivateKey(PrivateKeySupplierReason::Public_Account_Init);
+			[[maybe_unused]] auto privateKey = requestPrivateKey(PrivateKeySupplierReason::Public_Account_Init);
 		}
 		
 		return publicAccount_.value();

--- a/src/sdk/model/account/account.cpp
+++ b/src/sdk/model/account/account.cpp
@@ -37,7 +37,7 @@ namespace nem2_sdk {
 	const PublicAccount& Account::publicAccount() const
 	{
 		if (!publicAccount_) {
-			[[maybe_unused]] auto privateKey = requestPrivateKey(PrivateKeySupplierReason::Public_Account_Init);
+			requestPrivateKey(PrivateKeySupplierReason::Public_Account_Init);
 		}
 		
 		return publicAccount_.value();

--- a/src/sdk/model/account/address.cpp
+++ b/src/sdk/model/account/address.cpp
@@ -72,16 +72,26 @@ namespace nem2_sdk {
 		return data_;
 	}
 	
-	const std::string& Address::encoded() const
+	const std::string& Address::encoded() const&
 	{
 		return *encoded_;
 	}
-	
-	const std::string& Address::pretty() const
+
+	std::string&& Address::encoded() &&
+	{
+		return *std::move(encoded_);
+	}
+
+	const std::string& Address::pretty() const&
 	{
 		return *pretty_;
 	}
-	
+
+	std::string&& Address::pretty() &&
+	{
+		return *std::move(pretty_);
+	}
+
 	const uint8_t* Address::data() const
 	{
 		return data_.data();

--- a/src/sdk/service/binary_serialization.cpp
+++ b/src/sdk/service/binary_serialization.cpp
@@ -476,7 +476,6 @@ namespace nem2_sdk {
 	}
 	
 	
-	
 	std::vector<uint8_t> TransactionToBinary(const Transaction* transaction)
 	{
 		return transaction->binary();
@@ -508,7 +507,7 @@ namespace nem2_sdk {
 		description << "'" << GetTransactionName(header.value<"type"_>()) << "': ";
 		
 		if (ExtractTransactionVersion(header.value<"version"_>()) != GetTransactionVersion(header.value<"type"_>())) {
-			return { ReadResultCode::Failure, header.value<"size"_>(), description << "incorrect version" };
+			return { ReadResultCode::Failure, header.value<"size"_>(), (description << "incorrect version").str() };
 		}
 		
 		switch (header.value<"type"_>()) {
@@ -704,7 +703,7 @@ namespace nem2_sdk {
 		if (transaction) {
 			return { ReadResultCode::Success, header.value<"size"_>() };
 		} else {
-			return { ReadResultCode::Failure, header.value<"size"_>(), description << "incorrect data" };
+			return { ReadResultCode::Failure, header.value<"size"_>(), (description << "incorrect data").str() };
 		}
 	}
 }

--- a/src/sdk/service/read_result.cpp
+++ b/src/sdk/service/read_result.cpp
@@ -3,7 +3,7 @@
 
 namespace nem2_sdk {
 	
-	ReadResult::ReadResult(ReadResultCode code, size_t consumed, const std::string& description):
+	ReadResult::ReadResult(ReadResultCode code, size_t consumed, std::string_view description):
 		code_(code),
 		description_(description),
 		consumed_(consumed)

--- a/src/sdk/utils/format.cpp
+++ b/src/sdk/utils/format.cpp
@@ -3,8 +3,13 @@
 
 namespace nem2_sdk {
 	
-	MakeString::operator std::string() const
+	std::string MakeString::str() const
 	{
 		return stream_.str();
+	}
+
+	MakeString::operator std::string() const
+	{
+		return str();
 	}
 }


### PR DESCRIPTION
This PR introduce following changes:
* template class 'Hex' which can be used to automatically wrap/unwrap data in hex string during json reading/writing
* modified binary and json parser compile-time checks (produce more readable compiler errors when parser is called with invalid type)
* several new type traits and minor fixes to some old one. 

Closes #3.