### PR TITLE
Add special field "__data" to Json DTOs

### DIFF
--- a/src/infrastructure/binary/parser.h
+++ b/src/infrastructure/binary/parser.h
@@ -93,7 +93,7 @@ namespace nem2_sdk { namespace internal { namespace binary {
 		{
 			if constexpr (std::is_integral_v<TField> || std::is_enum_v<TField> || is_array_ext_v<TField> || is_variadic_struct_v<TField>) {
 				if constexpr (!std::is_same_v<TDescriptor, void>) {
-					static_assert(sizeof(TField) == 0, "invalid field descriptor (should be void)");
+					static_assert(sizeof(TField) == 0, "invalid field descriptor (should be 'void')");
 				}
 
 				if constexpr (is_array_ext_v<TField>) {
@@ -101,7 +101,7 @@ namespace nem2_sdk { namespace internal { namespace binary {
 				}
 			} else if constexpr (!IsItem && (is_specialization_v<TField, std::vector> || std::is_same_v<TField, std::string>)) {
 				if constexpr (desc::is_variable_size_v<TDescriptor> || desc::is_trailing_size_v<TDescriptor>) {
-					if constexpr (!has_field_by_name<typename TDescriptor::SizeFieldName, TStruct>::value) {
+					if constexpr (!has_field_by_name_v<typename TDescriptor::SizeFieldName, TStruct>) {
 						static_assert(sizeof(TField) == 0, "unknown size field name");
 					} else if constexpr (!std::is_integral_v<typename struct_field_by_name<typename TDescriptor::SizeFieldName, TStruct>::ValueType>) {
 						static_assert(sizeof(TField) == 0, "invalid size field type (should be integral)");

--- a/src/infrastructure/json/parser.cpp
+++ b/src/infrastructure/json/parser.cpp
@@ -30,18 +30,22 @@ namespace nem2_sdk { namespace internal { namespace json {
 	
 	std::string Parser::getData(OutputMode mode) const
 	{
+		return ValueToString(&document_, mode);
+	}
+
+	std::string Parser::ValueToString(const rapidjson::Value* value, OutputMode mode)
+	{
 		using namespace rapidjson;
-		
 		StringBuffer buffer;
-		
+
 		if (mode == OutputMode::Pretty) {
 			PrettyWriter<StringBuffer> writer(buffer);
-			document_.Accept(writer);
+			value->Accept(writer);
 		} else {
 			Writer<StringBuffer> writer(buffer);
-			document_.Accept(writer);
+			value->Accept(writer);
 		}
-		
+
 		return buffer.GetString();
 	}
 }}}

--- a/src/infrastructure/utils/variadic_struct.h
+++ b/src/infrastructure/utils/variadic_struct.h
@@ -3,6 +3,7 @@
 
 #include <any>
 #include <cstdint>
+#include <limits>
 #include <tuple>
 #include <type_traits>
 #include <utility>
@@ -15,7 +16,7 @@ namespace nem2_sdk { namespace internal {
 	template<typename T> struct is_variadic_struct;
 	template<typename TStruct> struct struct_size;
 	template<typename TStruct> struct struct_parent;
-	template<uint64_t Id, typename TStruct> struct has_field_by_id;;
+	template<uint64_t Id, typename TStruct> struct has_field_by_id;
 	template<typename TLiteral, typename TStruct> struct has_field_by_name;
 	template<size_t I, typename TStruct> struct struct_field_by_index;
 	template<uint64_t Id, typename TStruct> struct struct_field_by_id;
@@ -390,6 +391,12 @@ namespace nem2_sdk { namespace internal {
 		public has_field_by_id<FnvHash(StringLiteral<chars...>::Value), VariadicStruct<TFields...>>
 	{ };
 
+	template<uint64_t Id, typename TStruct>
+	constexpr bool has_field_by_id_v = has_field_by_id<Id, TStruct>::value;
+
+	template<typename TLiteral, typename TStruct>
+	constexpr bool has_field_by_name_v = has_field_by_name<TLiteral, TStruct>::value;
+	
 	template<size_t I, typename TName, typename TValue, typename TDescriptor, typename... TFields>
 	struct struct_field_by_index<I, VariadicStruct<Field<TName, TValue, TDescriptor>, TFields...>>:
 		public struct_field_by_index<I - 1, VariadicStruct<TFields...>>


### PR DESCRIPTION
This special field is filled with raw json object data by json parser when reading DTO from string. During writing DTO to string if this field is present and initialized in DTO, then it's data is merged with DTO fields (DTO fields take precedence over fields from "__data").

Closes #4 .